### PR TITLE
OM-329: add contribution point to render custom dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 
 ## Available Contribution Points
 
-- `home.HomePage.Container`: Use to override the container of the homepage completely (default: display `home.HomePage.Blocks`)
+- `home.HomePage.Container`: Use to extend the container of the homepage completely (default: display `home.HomePage.Blocks`)
 - `home.HomePage.Blocks`: Blocks displayed on the homepage. The current `user` is passed to each contribution. An example of block can be found on the [Claim management module](https://github.com/openimis/openimis-fe-claim_js)
+- `home.HomePage.customDashboard`: A contribution key that enables rendering a custom dashboard as the homepage. To activate this, a component must be provided with the `home.HomePage.customDashboard` contribution key, and the __HomePage.enableCustomDashboard__ configuration must be set to __true__ in the database.
 
 ## Configurations Options
 
 - `HomePageContainer.showHomeMessage`: a boolean configuration flag that determines whether or not a special message will be displayed on the home page. If set to true, the application will fetch and display HTML content based on the URL specified in **HomePageContainer.homeMessageURL**. By default, this is set to false. It means that no additional message will be displayed on the home page.
 - `HomePageContainer.homeMessageURL`: a string configuration that specifies the URL from which to fetch the HTML payload for display on the home page. By default, this is set to an empty string (""), meaning no URL is specified. This URL is used only when **HomePageContainer.showHomeMessage** is set to true.
 - `HomePageContainer.showHealthFacilityMessage`: boolean to show HF status information. It shows days to the end of the contract of a HF assigned to a current user. Default false.
+- `HomePage.enableCustomDashboard`: a boolean configuration flag that exposes the `home.HomePage.customDashboard` contribution key. This key allows overriding the default homepage to render a custom dashboard. **NOTE**: The custom page will not be rendered unless a component is provided with the `home.HomePage.customDashboard` contribution key.

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,10 +2,12 @@ export const DEFAULT = {
   SHOW_HOME_MESSAGE: false,
   HOME_MESSAGE_URL: "",
   SHOW_HEALTH_FACILITY_MESSAGE: false,
+  ENABLE_CUSTOM_DASHBOARD: false,
 };
 
 export const DAYS_HF_STATUS = {
   DAYS_LONG_TIME_ACTIVE: 180,
   DAYS_MEDIUM_TIME_ACTIVE: 30,
 };
+
 export const MODULE_NAME = "home";

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,7 +1,20 @@
-import { Contributions } from "@openimis/fe-core";
 import React from "react";
 
+import { Contributions, useModulesManager } from "@openimis/fe-core";
+import { DEFAULT } from "../constants";
+
 const HomePage = (props) => {
+  const modulesManager = useModulesManager();
+  const enableCustomDashboard = modulesManager.getConf(
+    "fe-home",
+    "HomePage.enableCustomDashboard",
+    DEFAULT.ENABLE_CUSTOM_DASHBOARD
+  );
+
+  if (enableCustomDashboard) {
+    return <Contributions contributionKey="home.HomePage.customDashboard" />;
+  }
+
   return <Contributions contributionKey="home.HomePage.Container" {...props} />;
 };
 


### PR DESCRIPTION
[OM-329](https://openimis.atlassian.net/browse/OM-329)

Changes:
- Extend db config by adding `HomePage.enableCustomDashboard`. It allows to access the `home.HomePage.customDashboard` contribution point. In result, rendering a custom dashboard is possible.
- Add `home.HomePage.customDashboard` contribution point. It allows to render a custom dashboard.
- Update readme.

[OM-329]: https://openimis.atlassian.net/browse/OM-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ